### PR TITLE
Move dependency repositories to allprojects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,33 +13,40 @@ plugins {
     id("com.github.jakemarsden.git-hooks")
 }
 
-repositories {
-    mavenLocal()
-    google()
+allprojects {
+    repositories {
+        mavenLocal()
+        google()
 
-    maven {
-        name = "Kotlin Discord"
-        url = uri("https://maven.kotlindiscord.com/repository/maven-public/")
-    }
+        maven {
+            name = "Sonatype Snapshots"
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots")
+        }
 
-    maven {
-        name = "Fabric"
-        url = uri("https://maven.fabricmc.net")
-    }
+        maven {
+            name = "Kotlin Discord"
+            url = uri("https://maven.kotlindiscord.com/repository/maven-public/")
+        }
 
-    maven {
-        name = "QuiltMC (Releases)"
-        url = uri("https://maven.quiltmc.org/repository/release/")
-    }
+        maven {
+            name = "Fabric"
+            url = uri("https://maven.fabricmc.net")
+        }
 
-    maven {
-        name = "QuiltMC (Snapshots)"
-        url = uri("https://maven.quiltmc.org/repository/snapshot/")
-    }
+        maven {
+            name = "QuiltMC (Releases)"
+            url = uri("https://maven.quiltmc.org/repository/release/")
+        }
 
-    maven {
-        name = "JitPack"
-        url = uri("https://jitpack.io")
+        maven {
+            name = "QuiltMC (Snapshots)"
+            url = uri("https://maven.quiltmc.org/repository/snapshot/")
+        }
+
+        maven {
+            name = "JitPack"
+            url = uri("https://jitpack.io")
+        }
     }
 }
 

--- a/module-user-cleanup/build.gradle.kts
+++ b/module-user-cleanup/build.gradle.kts
@@ -9,21 +9,6 @@ plugins {
     `cozy-module`
 }
 
-repositories {
-    mavenLocal()
-    google()
-
-    maven {
-        name = "QuiltMC (Releases)"
-        url = uri("https://maven.quiltmc.org/repository/release/")
-    }
-
-    maven {
-        name = "QuiltMC (Snapshots)"
-        url = uri("https://maven.quiltmc.org/repository/snapshot/")
-    }
-}
-
 dependencies {
     detektPlugins(libs.detekt)
 


### PR DESCRIPTION
also since the snapshot repository is no longer mirrored by kordex, it's added into the repository list