### PR TITLE
Add PlayerIPParser

### DIFF
--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/LogParsingExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/LogParsingExtension.kt
@@ -14,10 +14,7 @@ import dev.kord.common.entity.MessageType
 import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.message.create.embed
 import org.quiltmc.community.inQuiltGuild
-import org.quiltmc.community.modes.quilt.extensions.logs.parsers.BaseLogParser
-import org.quiltmc.community.modes.quilt.extensions.logs.parsers.FabricImplParser
-import org.quiltmc.community.modes.quilt.extensions.logs.parsers.FabricLoaderParser
-import org.quiltmc.community.modes.quilt.extensions.logs.parsers.LoaderVersionParser
+import org.quiltmc.community.modes.quilt.extensions.logs.parsers.*
 import org.quiltmc.community.modes.quilt.extensions.logs.retrievers.AttachmentLogRetriever
 import org.quiltmc.community.modes.quilt.extensions.logs.retrievers.BaseLogRetriever
 import org.quiltmc.community.modes.quilt.extensions.logs.retrievers.RawLogRetriever
@@ -30,6 +27,7 @@ class LogParsingExtension : Extension() {
         FabricLoaderParser(),
         FabricImplParser(),
         LoaderVersionParser(),
+        PlayerIPParser()
     )
 
     private val retrievers: List<BaseLogRetriever> = listOf(

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/PlayerIPParser.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/PlayerIPParser.kt
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.quiltmc.community.modes.quilt.extensions.logs.parsers
+
+private const val IP_REGEX =
+    "[a-zA-Z]+\\[/[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+:[0-9]+] logged in with entity id"
+
+class PlayerIPParser : BaseLogParser {
+    override suspend fun getMessages(logContent: String): List<String> {
+        val messages: MutableList<String> = mutableListOf()
+
+        if (logContent.contains(IP_REGEX)) {
+            @Suppress("MaximumLineLength")
+            messages.add(
+                "You appear to have shared player IP addresses. " +
+                        "You may want to delete that and re-upload it without them."
+            )
+        }
+
+        return messages
+    }
+}

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/PlayerIPParser.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/PlayerIPParser.kt
@@ -6,18 +6,20 @@
 
 package org.quiltmc.community.modes.quilt.extensions.logs.parsers
 
-private const val IP_REGEX =
-    "[a-zA-Z]+\\[/[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+:[0-9]+] logged in with entity id"
+private val IPV4_REGEX =
+    "(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}".toRegex()
+private val IPV6_REGEX =
+    "(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}".toRegex()
 
 class PlayerIPParser : BaseLogParser {
     override suspend fun getMessages(logContent: String): List<String> {
         val messages: MutableList<String> = mutableListOf()
 
-        if (logContent.contains(IP_REGEX)) {
-            @Suppress("MaximumLineLength")
+        if (logContent.contains(IPV4_REGEX) || logContent.contains(IPV6_REGEX)) {
             messages.add(
-                "You appear to have shared player IP addresses. " +
-                        "You may want to delete that and re-upload it without them."
+                "This log appears to contain players' IP addresses - " +
+                        "please consider deleting your uploaded log, " +
+                        "and posting it again with the IP addresses removed."
             )
         }
 


### PR DESCRIPTION
Adds player IP log filter to alert and warn users if they post a log that contains player IPs