### PR TITLE
Add role syncing module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,10 +79,11 @@ dependencies {
     implementation(libs.kx.ser)
     implementation(libs.graphql)
 
-    implementation(project(":module-welcome"))
-    implementation(project(":module-user-cleanup"))
-    implementation(project(":module-tags"))
     implementation(project(":module-moderation"))
+    implementation(project(":module-role-sync"))
+    implementation(project(":module-tags"))
+    implementation(project(":module-user-cleanup"))
+    implementation(project(":module-welcome"))
 }
 
 graphql {

--- a/module-role-sync/build.gradle.kts
+++ b/module-role-sync/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+plugins {
+    `api-module`
+    `cozy-module`
+    `published-module`
+}
+
+dependencies {
+    detektPlugins(libs.detekt)
+
+    ksp(libs.kordex.annotationProcessor)
+
+    implementation(libs.kordex.annotations)
+    implementation(libs.kordex.core)
+
+    implementation(libs.logging)
+
+    implementation(platform(libs.kotlin.bom))
+    implementation(libs.kotlin.stdlib)
+}

--- a/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncExtension.kt
+++ b/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncExtension.kt
@@ -1,0 +1,97 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.quiltmc.community.cozy.modules.rolesync
+
+import com.kotlindiscord.kord.extensions.annotations.DoNotChain
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
+import com.kotlindiscord.kord.extensions.extensions.event
+import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.utils.hasRole
+import dev.kord.core.event.guild.MemberUpdateEvent
+import kotlinx.coroutines.flow.filter
+import org.quiltmc.community.cozy.modules.rolesync.config.RoleSyncConfig
+
+/**
+ * Module providing role sync functionality.
+ *
+ * When one of the source role is added or removed from a user, the user is added or removed from the target role.
+ */
+public class RoleSyncExtension(
+    private val config: RoleSyncConfig
+) : Extension() {
+    override val name: String = RoleSyncPlugin.id
+
+    @OptIn(DoNotChain::class)
+    override suspend fun setup() {
+        event<MemberUpdateEvent> {
+            action {
+                // Make sure the old member is available
+                if (event.old == null) return@action
+
+                // Check if the roles have changed
+                if (event.old!!.roleIds == event.member.roleIds) return@action
+
+                for (role in config.getRolesToSync()) {
+                    // Check if the role got added
+                    if (!event.old!!.roleIds.contains(role.source) && event.member.roleIds.contains(role.source)) {
+                        getGuildForRoleSnowflake(role.target, bot).guild
+                            .getMember(event.member.id)
+                            .addRole(role.target, "Role synced")
+                    }
+                    // Check if the role got removed
+                    else if (event.old!!.roleIds.contains(role.source) && !event.member.roleIds.contains(role.source)) {
+                        getGuildForRoleSnowflake(role.target, bot).guild
+                            .getMember(event.member.id)
+                            .removeRole(role.target, "Role synced")
+                    }
+                }
+            }
+        }
+
+        ephemeralSlashCommand() {
+            name = "role-sync"
+            description = "Manually sync roles"
+
+            config.getCommandChecks().forEach(::check)
+
+            action {
+                var added = 0
+                var removed = 0
+
+                for (role in config.getRolesToSync()) {
+                    val targetRole = getGuildForRoleSnowflake(role.target, bot)
+                    val sourceRole = getGuildForRoleSnowflake(role.source, bot)
+
+                    // Check if the target role should be removed
+                    targetRole.guild.members
+                        .filter { it.roleIds.contains(role.target) }  // Has the target role
+                        .filter {
+                            !sourceRole.guild.getMember(it.id).hasRole(sourceRole)
+                        }  // Doesn't have the source role
+                        .collect {
+                            it.removeRole(role.target, "Role synced")
+                            removed++
+                        }
+
+                    // Check if the target role should be added
+                    sourceRole.guild.members
+                        .filter { it.roleIds.contains(role.source) }  // Has the source role
+                        .filter {
+                            !targetRole.guild.getMember(it.id).hasRole(targetRole)
+                        }  // Doesn't have the target role
+                        .collect {
+                            it.addRole(role.target, "Role synced")
+                            added++
+                        }
+                }
+
+                respond { content = "$added role(s) added, $removed role(s) removed" }
+            }
+        }
+    }
+}

--- a/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncExtension.kt
+++ b/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncExtension.kt
@@ -31,20 +31,23 @@ public class RoleSyncExtension(
         event<MemberUpdateEvent> {
             action {
                 // Make sure the old member is available
-                if (event.old == null) return@action
+                event.old ?: return@action
 
                 // Check if the roles have changed
-                if (event.old!!.roleIds == event.member.roleIds) return@action
+                if (event.old!!.roleIds == event.member.roleIds) { return@action }
 
                 for (role in config.getRolesToSync()) {
-                    // Check if the role got added
                     if (!event.old!!.roleIds.contains(role.source) && event.member.roleIds.contains(role.source)) {
+                        // Role was added
+
                         getGuildForRoleSnowflake(role.target, bot).guild
                             .getMember(event.member.id)
                             .addRole(role.target, "Role synced")
-                    }
-                    // Check if the role got removed
-                    else if (event.old!!.roleIds.contains(role.source) && !event.member.roleIds.contains(role.source)) {
+                    } else if (
+                        event.old!!.roleIds.contains(role.source) && !event.member.roleIds.contains(role.source)
+                    ) {
+                        // Role was removed
+
                         getGuildForRoleSnowflake(role.target, bot).guild
                             .getMember(event.member.id)
                             .removeRole(role.target, "Role synced")

--- a/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncExtension.kt
+++ b/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncExtension.kt
@@ -19,7 +19,7 @@ import org.quiltmc.community.cozy.modules.rolesync.config.RoleSyncConfig
 /**
  * Module providing role sync functionality.
  *
- * When one of the source role is added or removed from a user, the user is added or removed from the target role.
+ * When one of the source roles is added or removed from a user, the user is added or removed from the target role.
  */
 public class RoleSyncExtension(
     private val config: RoleSyncConfig

--- a/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncPlugin.kt
+++ b/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/RoleSyncPlugin.kt
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.quiltmc.community.cozy.modules.rolesync
+
+import com.kotlindiscord.kord.extensions.plugins.KordExPlugin
+import com.kotlindiscord.kord.extensions.plugins.annotations.plugins.WiredPlugin
+import org.pf4j.PluginWrapper
+
+/**
+ * Plugin containing the [RoleSyncPlugin], providing various moderation tools.
+ */
+@WiredPlugin(
+    id = RoleSyncPlugin.id,
+    version = "1.0.0-SNAPSHOT",
+
+    author = "QuiltMC",
+    description = "Various moderation tools for the QuiltMC community.",
+    license = "Mozilla Public License 2.0"
+)
+public class RoleSyncPlugin(wrapper: PluginWrapper) : KordExPlugin(wrapper) {
+    override suspend fun setup() {
+// TODO: We can't really use the plugin system just yet since it doesn't currently support any configuration tooling
+//        extension(::RoleSyncExtension)
+    }
+
+    public companion object {
+        public const val id: String = "quiltmc-role-sync"
+    }
+}

--- a/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/_Utils.kt
+++ b/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/_Utils.kt
@@ -1,0 +1,29 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.quiltmc.community.cozy.modules.rolesync
+
+import com.kotlindiscord.kord.extensions.ExtensibleBot
+import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
+import dev.kord.common.entity.Snowflake
+import dev.kord.core.Kord
+import dev.kord.core.entity.Role
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapConcat
+import org.quiltmc.community.cozy.modules.rolesync.config.RoleSyncConfig
+import org.quiltmc.community.cozy.modules.rolesync.config.SimpleRoleSyncConfig
+
+@OptIn(FlowPreview::class)
+public suspend fun getGuildForRoleSnowflake(roleId: Snowflake, bot: ExtensibleBot): Role =
+    bot.getKoin().get<Kord>().guilds.flatMapConcat { it.roles }.first { it.id == roleId }
+
+public fun ExtensibleBotBuilder.ExtensionsBuilder.rolesync(config: RoleSyncConfig) {
+    add { RoleSyncExtension(config) }
+}
+
+public fun ExtensibleBotBuilder.ExtensionsBuilder.rolesync(body: SimpleRoleSyncConfig.Builder.() -> Unit): Unit =
+    rolesync(SimpleRoleSyncConfig(body))

--- a/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/config/RoleSyncConfig.kt
+++ b/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/config/RoleSyncConfig.kt
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.quiltmc.community.cozy.modules.rolesync.config
+
+import com.kotlindiscord.kord.extensions.checks.types.Check
+import dev.kord.common.entity.Snowflake
+
+/**
+ * The roles to sync between the two guilds.
+ *
+ * @param source The source role to sync. Modifications to this role will be synced to the target role.
+ * @param target The target role that will be synced when the source role is changed.
+ */
+public data class RoleToSync(
+    val source: Snowflake,
+    val target: Snowflake,
+)
+
+/**
+ * Class representing the configuration for the role sync module.
+ *
+ * Extend this class to implement your configuration loader. If you only need a basic config, then you can
+ * take a look at [SimpleRoleSyncConfig] instead.
+ */
+public open class RoleSyncConfig {
+    /**
+     * Override this to specify the roles that should be synced.
+     */
+    public open suspend fun getRolesToSync(): List<RoleToSync> = listOf()
+
+    /**
+     * Override this to provide a list of KordEx [Check]s that must pass for commands to be executed.
+     */
+    public open suspend fun getCommandChecks(): List<Check<*>> = listOf()
+}

--- a/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/config/SimpleRoleSyncConfig.kt
+++ b/module-role-sync/src/main/kotlin/org/quiltmc/community/cozy/modules/rolesync/config/SimpleRoleSyncConfig.kt
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.quiltmc.community.cozy.modules.rolesync.config
+
+import com.kotlindiscord.kord.extensions.checks.types.Check
+import dev.kord.common.entity.Snowflake
+
+public class SimpleRoleSyncConfig(builder: Builder) : RoleSyncConfig() {
+    private val rolesToSync: MutableList<RoleToSync> = builder.rolesToSync
+    private val commandChecks: MutableList<Check<*>> = builder.commandChecks
+
+    override suspend fun getRolesToSync(): List<RoleToSync> =
+        rolesToSync
+
+    override suspend fun getCommandChecks(): List<Check<*>> =
+        commandChecks
+
+    public class Builder {
+        internal var rolesToSync: MutableList<RoleToSync> = mutableListOf()
+        internal val commandChecks: MutableList<Check<*>> = mutableListOf()
+
+        public fun roleToSync(source: Snowflake, target: Snowflake) {
+            rolesToSync.add(RoleToSync(source, target))
+        }
+
+        public fun commandCheck(body: Check<*>) {
+            commandChecks.add(body)
+        }
+    }
+}
+
+public inline fun SimpleRoleSyncConfig(body: SimpleRoleSyncConfig.Builder.() -> Unit): SimpleRoleSyncConfig {
+    val builder = SimpleRoleSyncConfig.Builder()
+
+    body(builder)
+
+    return SimpleRoleSyncConfig(builder)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,8 @@ dependencyResolutionManagement {
     }
 }
 
-include(":module-user-cleanup")
 include(":module-moderation")
+include(":module-role-sync")
 include(":module-tags")
+include(":module-user-cleanup")
 include(":module-welcome")

--- a/src/main/kotlin/org/quiltmc/community/App.kt
+++ b/src/main/kotlin/org/quiltmc/community/App.kt
@@ -23,6 +23,7 @@ import dev.kord.gateway.Intents
 import dev.kord.gateway.PrivilegedIntent
 import org.quiltmc.community.cozy.modules.cleanup.userCleanup
 import org.quiltmc.community.cozy.modules.moderation.moderation
+import org.quiltmc.community.cozy.modules.rolesync.rolesync
 import org.quiltmc.community.cozy.modules.tags.tags
 import org.quiltmc.community.cozy.modules.welcome.welcomeChannel
 import org.quiltmc.community.database.collections.ServerSettingsCollection
@@ -148,6 +149,16 @@ suspend fun setupQuilt() = ExtensibleBot(DISCORD_TOKEN) {
 
         moderation {
             loggingChannelName = "cozy-logs"
+
+            commandCheck { inQuiltGuild() }
+            commandCheck { hasBaseModeratorRole() }
+        }
+
+        rolesync {
+            roleToSync(
+                TOOLCHAIN_DEVELOPER_ROLE,
+                COMMUNITY_DEVELOPER_ROLE
+            )
 
             commandCheck { inQuiltGuild() }
             commandCheck { hasBaseModeratorRole() }

--- a/src/main/kotlin/org/quiltmc/community/_Constants.kt
+++ b/src/main/kotlin/org/quiltmc/community/_Constants.kt
@@ -37,10 +37,10 @@ internal val COMMUNITY_MODERATOR_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.l
 internal val TOOLCHAIN_MODERATOR_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
     ?: Snowflake(863767485609541632)
 
-internal val COMMUNITY_DEVELOPER_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.let { Snowflake(it) }
+internal val COMMUNITY_DEVELOPER_ROLE = envOrNull("COMMUNITY_DEVELOPER_ROLE")?.let { Snowflake(it) }
     ?: Snowflake(972868531844710412)
 
-internal val TOOLCHAIN_DEVELOPER_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
+internal val TOOLCHAIN_DEVELOPER_ROLE = envOrNull("TOOLCHAIN_DEVELOPER_ROLE")?.let { Snowflake(it) }
     ?: Snowflake(849305976951537725)
 
 internal val MODERATOR_ROLES: List<Snowflake> =

--- a/src/main/kotlin/org/quiltmc/community/_Constants.kt
+++ b/src/main/kotlin/org/quiltmc/community/_Constants.kt
@@ -37,6 +37,12 @@ internal val COMMUNITY_MODERATOR_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.l
 internal val TOOLCHAIN_MODERATOR_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
     ?: Snowflake(863767485609541632)
 
+internal val COMMUNITY_DEVELOPER_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.let { Snowflake(it) }
+    ?: Snowflake(972868531844710412)
+
+internal val TOOLCHAIN_DEVELOPER_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
+    ?: Snowflake(849305976951537725)
+
 internal val MODERATOR_ROLES: List<Snowflake> =
     (envOrNull("MODERATOR_ROLES") ?: envOrNull("COMMUNITY_MANAGEMENT_ROLES")) // For now, back compat
         ?.split(',')


### PR DESCRIPTION
This module will sync source and target roles. When a user gets added or removed the source role, the bot will copy those changes to the target role.

Roles can span across guilds. The `/sync-role` command can also be used to manually sync the roles.

The module is already configured to sync the "Quilt Developer" role from the Toolchain server to the Community server.