### PR TITLE
Setting: fix copy paste error

### DIFF
--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/settings/SettingsExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/settings/SettingsExtension.kt
@@ -157,7 +157,7 @@ class SettingsExtension : Extension() {
                         flags.save()
 
                         respond {
-                            content = "Nickname sync **" + if (flags.autoPublish) {
+                            content = "Nickname sync **" + if (flags.syncNicks) {
                                 "enabled"
                             } else {
                                 "disabled"


### PR DESCRIPTION
The feedback message for `/config nick-sync` is wrong due to a copy paste error.