### PR TITLE
Logs: filter available QSL by the game version

### DIFF
--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/QSLVersionParser.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/QSLVersionParser.kt
@@ -65,10 +65,13 @@ class QSLVersionParser : BaseLogParser {
         val now = Clock.System.now()
 
         if (latestVersion == null || lastCheck == null || now - lastCheck!! > CACHE_TIMEOUT) {
-            val response: List<ModrinthVersion> = client.get(MODRINTH_URL).body()
+            val response: List<ModrinthVersion> = client.get(MODRINTH_URL) {
+                url {
+                    parameters.append("game_versions", "[\"${minecraftVersion}\"]")
+                }
+            }.body()
 
             val latest = response
-                .filter { it.gameVersions.contains(minecraftVersion) }
                 .maxByOrNull { it.datePublished }
                 ?: return null
 


### PR DESCRIPTION
# Changes

This caused the bot to suggest to 1.18.2 users to upgrade to QSL 2.0.0, which is only available for 1.19. Fixed it by filtering by the minecraft version beforehand.

Closes #44 

# Demo

This is using 1.18.2 with 1.0.0-beta.17+0.54.0-1.18.2

## Before

![image](https://user-images.githubusercontent.com/44778521/173232978-06e33dbd-80c3-4baa-ab94-8b91019db3f1.png)

## After

![image](https://user-images.githubusercontent.com/44778521/173232986-05370ac9-c0a8-46ad-bf35-f4589beeb33a.png)
