### PR TITLE
feat: termbin and hastebin

### DIFF
--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/retrievers/RawLogRetriever.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/retrievers/RawLogRetriever.kt
@@ -22,7 +22,8 @@ private val strategyMap: Map<Regex, String> = mutableMapOf(
 	"pastes.dev/$SLUG".toRegex() to "https://api.pastes.dev/$1",
 	"termbin.com/$SLUG".toRegex() to "https://termbin.com/$1",
 	"hastebin.com/$SLUG".toRegex() to "https://hastebin.com/raw/$1",
-	"https://www.toptal.com/developers/hastebin/$SLUG".toRegex() to "https://www.toptal.com/developers/hastebin/raw/$1"
+	"toptal.com/developers/hastebin/$SLUG".toRegex() to "https://www.toptal.com/developers/hastebin/raw/$1",
+	"hst.sh/$SLUG".toRegex() to "https://hst.sh/raw/$1",
 
 	"gist.github.com/$SLUG/$SLUG".toRegex() to "https://gist.githubusercontent.com/raw/$2",
 	"gist.github.com/$SLUG".toRegex() to "https://gist.githubusercontent.com/raw/$1",

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/retrievers/RawLogRetriever.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/retrievers/RawLogRetriever.kt
@@ -20,6 +20,9 @@ private val strategyMap: Map<Regex, String> = mutableMapOf(
 	"mclo.gs/$SLUG".toRegex() to "https://api.mclo.gs/1/raw/$1",
 	"paste.ee/[pd]/$SLUG".toRegex() to "https://paste.ee/d/$1",
 	"pastes.dev/$SLUG".toRegex() to "https://api.pastes.dev/$1",
+	"termbin.com/$SLUG".toRegex() to "https://termbin.com/$1",
+	"hastebin.com/$SLUG".toRegex() to "https://hastebin.com/raw/$1",
+	"https://www.toptal.com/developers/hastebin/$SLUG".toRegex() to "https://www.toptal.com/developers/hastebin/raw/$1"
 
 	"gist.github.com/$SLUG/$SLUG".toRegex() to "https://gist.githubusercontent.com/raw/$2",
 	"gist.github.com/$SLUG".toRegex() to "https://gist.githubusercontent.com/raw/$1",


### PR DESCRIPTION
Adds logs support for [termbin](https://termbin.com), [hastebin](https://hastebin.com).

For hastebin, I've added 3 different instances (although hastebin.com is deprecated and is just a redirect to the new site at toptal.com, it's there just to be safe).