### PR TITLE
Allow staff commands to community managers

### DIFF
--- a/src/main/kotlin/org/quiltmc/community/_Checks.kt
+++ b/src/main/kotlin/org/quiltmc/community/_Checks.kt
@@ -114,7 +114,7 @@ suspend fun CheckContext<*>.inQuiltGuild() {
 	}
 }
 
-suspend fun CheckContext<*>.hasBaseModeratorRole() {
+suspend fun CheckContext<*>.hasBaseModeratorRole(includeCommunityManagers: Boolean = true) {
 	if (!passed) {
 		return
 	}
@@ -130,16 +130,21 @@ suspend fun CheckContext<*>.hasBaseModeratorRole() {
 
 			fail()
 		} else {
-			if (!member.roleIds.any { it in MODERATOR_ROLES }) {
-				logger.failed("Member does not have a Quilt base moderator role")
+			val hasModeratorRole = member.roleIds.any { it in MODERATOR_ROLES }
+			val hasCommunityManagerRole = member.roleIds.any { it in MANAGER_ROLES }
 
-				fail("Must be a Quilt moderator, with the `Moderators` role")
+			if (!hasModeratorRole && (!hasCommunityManagerRole || !includeCommunityManagers)) {
+				val roleDescription = if (includeCommunityManagers) "Moderator or Community Manager" else "Moderator"
+
+				logger.failed("Member does not have a Quilt $roleDescription role")
+
+				fail("Must be a Quilt $roleDescription")
 			}
 		}
 	}
 }
 
-suspend fun CheckContext<*>.notHasBaseModeratorRole() {
+suspend fun CheckContext<*>.notHasBaseModeratorRole(includeCommunityManagers: Boolean = true) {
 	if (!passed) {
 		return
 	}
@@ -152,10 +157,15 @@ suspend fun CheckContext<*>.notHasBaseModeratorRole() {
 
 		fail()
 	} else {
-		if (member.roleIds.any { it in MODERATOR_ROLES }) {
-			logger.failed("Member has a Quilt base moderator role")
+		val hasModeratorRole = member.roleIds.any { it in MODERATOR_ROLES }
+		val hasCommunityManagerRole = member.roleIds.any { it in MANAGER_ROLES }
 
-			fail("Must **not** be a Quilt moderator")
+		if (hasModeratorRole || (hasCommunityManagerRole && includeCommunityManagers)) {
+			val roleDescription = if (includeCommunityManagers) "Moderator or Community Manager" else "Moderator"
+
+			logger.failed("Member has a Quilt $roleDescription role")
+
+			fail("Must **not** be a Quilt $roleDescription")
 		}
 	}
 }

--- a/src/main/kotlin/org/quiltmc/community/_Constants.kt
+++ b/src/main/kotlin/org/quiltmc/community/_Constants.kt
@@ -37,6 +37,12 @@ internal val COMMUNITY_MODERATOR_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.l
 internal val TOOLCHAIN_MODERATOR_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
 	?: Snowflake(863767485609541632)
 
+internal val COMMUNITY_MANAGER_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.let { Snowflake(it) }
+	?: Snowflake(832332800551813141)
+
+internal val TOOLCHAIN_MANAGER_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
+	?: Snowflake(833877938000494602)
+
 internal val COMMUNITY_DEVELOPER_ROLE = envOrNull("COMMUNITY_DEVELOPER_ROLE")?.let { Snowflake(it) }
 	?: Snowflake(972868531844710412)
 
@@ -48,6 +54,12 @@ internal val MODERATOR_ROLES: List<Snowflake> =
 		?.split(',')
 		?.map { Snowflake(it.trim()) }
 		?: listOf(COMMUNITY_MODERATOR_ROLE, TOOLCHAIN_MODERATOR_ROLE)
+
+internal val MANAGER_ROLES: List<Snowflake> =
+	(envOrNull("MANAGER_ROLES") ?: envOrNull("COMMUNITY_MANAGER_ROLES"))
+		?.split(',')
+		?.map { Snowflake(it.trim()) }
+		?: listOf(COMMUNITY_MANAGER_ROLE, TOOLCHAIN_MANAGER_ROLE)
 
 internal val MINECRAFT_UPDATE_PING_ROLE = envOrNull("MINECRAFT_UPDATE_PING_ROLE")?.let { Snowflake(it) }
 	?: Snowflake(1003614007237816361)

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/SubteamsExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/SubteamsExtension.kt
@@ -6,7 +6,6 @@
 
 package org.quiltmc.community.modes.quilt.extensions
 
-import com.kotlindiscord.kord.extensions.checks.hasRole
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
 import com.kotlindiscord.kord.extensions.commands.application.slash.publicSubCommand
@@ -20,9 +19,9 @@ import dev.kord.core.entity.Role
 import dev.kord.rest.builder.message.create.allowedMentions
 import org.koin.core.component.inject
 import org.quiltmc.community.TOOLCHAIN_GUILD
-import org.quiltmc.community.TOOLCHAIN_MODERATOR_ROLE
 import org.quiltmc.community.database.collections.TeamCollection
 import org.quiltmc.community.database.entities.Team
+import org.quiltmc.community.hasBaseModeratorRole
 
 class SubteamsExtension : Extension() {
 	override val name: String = "subteams"
@@ -101,7 +100,7 @@ class SubteamsExtension : Extension() {
 
 			guild(TOOLCHAIN_GUILD)
 
-			check { hasRole(TOOLCHAIN_MODERATOR_ROLE) }
+			check { hasBaseModeratorRole() }
 
 			ephemeralSubCommand(::ManageTeamAllowArguments) {
 				name = "allow"

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/filtering/FilterExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/filtering/FilterExtension.kt
@@ -164,7 +164,7 @@ class FilterExtension : Extension() {
 
 				allowInDms = false
 
-				check { hasBaseModeratorRole() }
+				check { hasBaseModeratorRole(false) }
 
 				guild(guildId)
 

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/github/GithubExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/github/GithubExtension.kt
@@ -127,7 +127,7 @@ class GithubExtension : Extension() {
 
 				allowInDms = false
 
-				check { hasBaseModeratorRole() }
+				check { hasBaseModeratorRole(false) }
 
 				guild(guildId)
 				requirePermission(Permission.BanMembers)

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/minecraft/MinecraftExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/minecraft/MinecraftExtension.kt
@@ -9,7 +9,6 @@ package org.quiltmc.community.modes.quilt.extensions.minecraft
 import com.kotlindiscord.kord.extensions.DISCORD_FUCHSIA
 import com.kotlindiscord.kord.extensions.DISCORD_GREEN
 import com.kotlindiscord.kord.extensions.checks.hasPermission
-import com.kotlindiscord.kord.extensions.checks.hasRole
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
 import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
@@ -156,10 +155,7 @@ class MinecraftExtension : Extension() {
 					name = "forget"
 					description = "Forget a version (the last one by default), allowing it to be relayed again."
 
-					when (guildId) {
-						COMMUNITY_GUILD -> check { hasRole(COMMUNITY_MODERATOR_ROLE) }
-						TOOLCHAIN_GUILD -> check { hasRole(TOOLCHAIN_MODERATOR_ROLE) }
-					}
+					check { hasBaseModeratorRole() }
 
 					check { hasPermission(Permission.Administrator) }
 
@@ -192,10 +188,7 @@ class MinecraftExtension : Extension() {
 					name = "run"
 					description = "Run the check task now, without waiting for it."
 
-					when (guildId) {
-						COMMUNITY_GUILD -> check { hasRole(COMMUNITY_MODERATOR_ROLE) }
-						TOOLCHAIN_GUILD -> check { hasRole(TOOLCHAIN_MODERATOR_ROLE) }
-					}
+					check { hasBaseModeratorRole() }
 
 					action {
 						respond { content = "Checking now..." }

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/suggestions/SuggestionsExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/suggestions/SuggestionsExtension.kt
@@ -10,7 +10,6 @@
 
 package org.quiltmc.community.modes.quilt.extensions.suggestions
 
-import com.kotlindiscord.kord.extensions.checks.hasRole
 import com.kotlindiscord.kord.extensions.checks.inTopChannel
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.converters.impl.optionalEnumChoice
@@ -302,7 +301,7 @@ class SuggestionsExtension : Extension() {
 
 			guild(COMMUNITY_GUILD)
 
-			check { hasRole(COMMUNITY_MODERATOR_ROLE) }
+			check { hasBaseModeratorRole() }
 
 			action {
 				val suggestions = suggestions.find(Suggestion::_id exists true).toList()
@@ -362,7 +361,7 @@ class SuggestionsExtension : Extension() {
 
 			guild(COMMUNITY_GUILD)
 
-			check { hasRole(COMMUNITY_MODERATOR_ROLE) }
+			check { hasBaseModeratorRole() }
 
 			action {
 				val status = arguments.status
@@ -533,6 +532,13 @@ class SuggestionsExtension : Extension() {
 					else -> return
 				}
 
+				val managerRole = when (thread.guildId) {
+					COMMUNITY_GUILD -> thread.guild.getRole(COMMUNITY_MANAGER_ROLE)
+					TOOLCHAIN_GUILD -> thread.guild.getRole(TOOLCHAIN_MANAGER_ROLE)
+
+					else -> return
+				}
+
 				val pingMessage = thread.createMessage {
 					content = "Oh right, better get the mods in..."
 				}
@@ -540,8 +546,8 @@ class SuggestionsExtension : Extension() {
 				delay(3.seconds)
 
 				pingMessage.edit {
-					content = "Oh right, better get the mods in...\n" +
-							"Hey, ${modRole.mention}! Squirrel!"
+					content = "Oh right, better get the staff in...\n" +
+							"Hey, ${modRole.mention} and ${managerRole.mention}! Squirrel!"
 				}
 
 				delay(3.seconds)


### PR DESCRIPTION
Previously, the assumption was made that community managers would always have a moderator role, which doesn't hold up anymore. This change the hasBaseModeratorRole and notHasBaseModeratorRole checks to include community managers by default. We did not include that role for strictly moderation related commands: the filter and github extension.

Here is our reasoning for not blocking some commands that may be more obscure:
- Moderation extension: This extension currently only provides the /slowmode command, which allows for more freedom than the Discord client normally gives you. Slowmode can be an integral part of setting up new channels or an organisation policy. We may need to introduce two checks in that extension in the long run.
- /lock and /unlock: We frequently lock and unlock channels outside of a moderation context, for example during meetings.

Feedback on what is allowed and not allowed is always welcome.