### PR TITLE
Filters: Add match type for Yubico OTPs

### DIFF
--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/filtering/MatchType.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/filtering/MatchType.kt
@@ -16,4 +16,5 @@ enum class MatchType(override val readableName: String) : ChoiceEnum {
 	REGEX("Target exactly matches this regular expression"),
 	REGEX_CONTAINS("Target contains this regular expression"),
 	INVITE("Target contains an invite for this guild ID"),
+	YUBICO_OTP("Target is a valid Yubico OTP using this client ID"),
 }


### PR DESCRIPTION
Yubico OTPs are easy to post by accident, especially with a YubiKey in its default configuration. A dedicated match type that validates with Yubicloud has the advantage over a simple regex filter that if someone manages to copy the OTP they would be unable to use it, and that if something happens to look like a Yubicloud OTP by coincidence then it won't be deleted. The filter "text" is a client ID which can be easily obtained from <https://upgrade.yubico.com/getapikey/>. 