### PR TITLE
Add mixin to set of internal packages for log analysis

### DIFF
--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/FabricImplParser.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/logs/parsers/FabricImplParser.kt
@@ -44,7 +44,7 @@ class FabricImplParser : BaseLogParser {
 		if (
 			suspectedMod != null &&
 			suspectedPackage != null &&
-			".fabricmc." in suspectedPackage && ".impl." in suspectedPackage
+			".fabricmc." in suspectedPackage && (".impl." in suspectedPackage || ".mixin." in suspectedPackage)
 		) {
 			messages.add(
 				"Mod `$suspectedMod` may be using Fabric internals:\n`$suspectedPackage`"


### PR DESCRIPTION
I could have *sworn* that I saw this come up in player support recently but cannot for the life of me actually find it, so uh, here's a quick patch anyways.