### PR TITLE
fix: allow CMs to use utility commands (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ ENVIRONMENT=dev
 * `COMMUNITY_GUILD_ID`: ID of your "community" server
 * `TOOLCHAIN_GUILD_ID`: ID of your "toolchain" server
 * `GUILDS`: A comma-separated list of guild IDs, if not just the two above
-* `COMMUNITY_MODERATOR_ROLE`: ID of your "toolchain moderator" role
-* `TOOLCHAIN_MODERATOR_ROLE`: ID of your "community moderator" role
+* `COMMUNITY_MODERATOR_ROLE`: ID of your "community moderator" role
+* `TOOLCHAIN_MODERATOR_ROLE`: ID of your "toolchain moderator" role
 * `MODERATOR_ROLES`: A comma-separated list of moderator role IDs, if not just the two above
 
 **Settings used by mode:** `quilt`

--- a/src/main/kotlin/org/quiltmc/community/_Constants.kt
+++ b/src/main/kotlin/org/quiltmc/community/_Constants.kt
@@ -37,10 +37,10 @@ internal val COMMUNITY_MODERATOR_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.l
 internal val TOOLCHAIN_MODERATOR_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
 	?: Snowflake(863767485609541632)
 
-internal val COMMUNITY_MANAGER_ROLE = envOrNull("COMMUNITY_MODERATOR_ROLE")?.let { Snowflake(it) }
+internal val COMMUNITY_MANAGER_ROLE = envOrNull("COMMUNITY_MANAGER_ROLE")?.let { Snowflake(it) }
 	?: Snowflake(832332800551813141)
 
-internal val TOOLCHAIN_MANAGER_ROLE = envOrNull("TOOLCHAIN_MODERATOR_ROLE")?.let { Snowflake(it) }
+internal val TOOLCHAIN_MANAGER_ROLE = envOrNull("TOOLCHAIN_MANAGER_ROLE")?.let { Snowflake(it) }
 	?: Snowflake(833877938000494602)
 
 internal val COMMUNITY_DEVELOPER_ROLE = envOrNull("COMMUNITY_DEVELOPER_ROLE")?.let { Snowflake(it) }

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/UtilityExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/UtilityExtension.kt
@@ -94,6 +94,10 @@ class UtilityExtension : Extension() {
 	override val name: String = "utility"
 
 	private val logger = KotlinLogging.logger { }
+	private val privilegedRoles = listOf(
+		MANAGER_ROLES,
+		MODERATOR_ROLES
+	).flatten()
 	private val threads: OwnedThreadCollection by inject()
 
 	private val userFlags: UserFlagsCollection by inject()
@@ -142,8 +146,8 @@ class UtilityExtension : Extension() {
 
 				if (flags.syncNicks) {
 					val otherMember = when (event.guild.id) {
-						COMMUNITY_GUILD -> kord.getGuild(TOOLCHAIN_GUILD)?.getMemberOrNull(event.member.id)
-						TOOLCHAIN_GUILD -> kord.getGuild(COMMUNITY_GUILD)?.getMemberOrNull(event.member.id)
+						COMMUNITY_GUILD -> kord.getGuildOrNull(TOOLCHAIN_GUILD)?.getMemberOrNull(event.member.id)
+						TOOLCHAIN_GUILD -> kord.getGuildOrNull(COMMUNITY_GUILD)?.getMemberOrNull(event.member.id)
 
 						else -> null
 					} ?: return@action
@@ -295,7 +299,7 @@ class UtilityExtension : Extension() {
 					val member = user.asMember(guild!!.id)
 					val roles = member.roles.toList().map { it.id }
 
-					if (MODERATOR_ROLES.any { it in roles }) {
+					if (privilegedRoles.any { it in roles }) {
 						targetMessages.forEach { it.pin("Pinned by ${member.tag}") }
 						edit { content = "Messages pinned." }
 
@@ -328,7 +332,7 @@ class UtilityExtension : Extension() {
 					val member = user.asMember(guild!!.id)
 					val roles = member.roles.toList().map { it.id }
 
-					if (MODERATOR_ROLES.any { it in roles }) {
+					if (privilegedRoles.any { it in roles }) {
 						targetMessages.forEach { it.unpin("Unpinned by ${member.tag}") }
 						edit { content = "Messages unpinned." }
 
@@ -506,7 +510,7 @@ class UtilityExtension : Extension() {
 						val member = user.asMember(guild!!.id)
 						val roles = member.roles.toList().map { it.id }
 
-						if (MODERATOR_ROLES.any { it in roles }) {
+						if (privilegedRoles.any { it in roles }) {
 							channel.edit {
 								name = arguments.name
 
@@ -546,7 +550,7 @@ class UtilityExtension : Extension() {
 						val roles = member.roles.toList().map { it.id }
 						val ownedThread = threads.get(channel)
 
-						if (MODERATOR_ROLES.any { it in roles }) {
+						if (privilegedRoles.any { it in roles }) {
 							if (ownedThread != null) {
 								ownedThread.preventArchiving = false
 								threads.set(ownedThread)
@@ -627,7 +631,7 @@ class UtilityExtension : Extension() {
 							return@action
 						}
 
-						if (MODERATOR_ROLES.any { it in roles }) {
+						if (privilegedRoles.any { it in roles }) {
 							arguments.message.pin("Pinned by ${member.tag}")
 							edit { content = "Message pinned." }
 
@@ -665,7 +669,7 @@ class UtilityExtension : Extension() {
 							return@action
 						}
 
-						if (MODERATOR_ROLES.any { it in roles }) {
+						if (privilegedRoles.any { it in roles }) {
 							arguments.message.unpin("Unpinned by ${member.tag}")
 							edit { content = "Message unpinned." }
 
@@ -764,7 +768,7 @@ class UtilityExtension : Extension() {
 						val previousOwner = thread.owner
 
 						if ((thread.owner != user.id && threads.isOwner(channel, user) != true) &&
-							!MODERATOR_ROLES.any { it in roles }
+							!privilegedRoles.any { it in roles }
 						) {
 							edit { content = "**Error:** This is not your thread." }
 							return@action
@@ -778,7 +782,7 @@ class UtilityExtension : Extension() {
 							return@action
 						}
 
-						if (MODERATOR_ROLES.any { it in roles }) {
+						if (privilegedRoles.any { it in roles }) {
 							thread.owner = arguments.user.id
 							threads.set(thread)
 


### PR DESCRIPTION
Fixes #58.

- Also includes a related README typo fix.
- Also changes what _may_ be a typo in `_Constants`, but the fix is in a separate commit just in case it isn't for easy reverting. 
- Replaces deprecated `getGuild` with `getGuildOrNull` because of angry Detekt preventing committing