### PR TITLE
Update to Kotlin 1.8.0. Bump KordEx and other dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ allprojects {
 
 dependencies {
 	detektPlugins(libs.detekt)
+	detektPlugins(libs.detekt.libraries)
 
 	ksp(libs.kordex.annotationProcessor)
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,15 +17,15 @@ dependencies {
 	implementation(gradleApi())
 	implementation(localGroovy())
 
-	implementation(kotlin("gradle-plugin", version = "1.7.10"))
-	implementation(kotlin("serialization", version = "1.7.0"))
+	implementation(kotlin("gradle-plugin", version = "1.8.0"))
+	implementation(kotlin("serialization", version = "1.8.0"))
 
 	implementation("gradle.plugin.org.cadixdev.gradle", "licenser", "0.6.1")
 	implementation("com.github.jakemarsden", "git-hooks-gradle-plugin", "0.0.2")
-	implementation("com.google.devtools.ksp", "com.google.devtools.ksp.gradle.plugin", "1.7.10-1.0.6")
-	implementation("io.gitlab.arturbosch.detekt", "detekt-gradle-plugin", "1.21.0-RC2")
+	implementation("com.google.devtools.ksp", "com.google.devtools.ksp.gradle.plugin", "1.8.0-1.0.9")
+	implementation("io.gitlab.arturbosch.detekt", "detekt-gradle-plugin", "1.22.0")
 	implementation("org.ec4j.editorconfig", "org.ec4j.editorconfig.gradle.plugin", "0.0.3")
 
-	implementation("com.expediagroup.graphql", "com.expediagroup.graphql.gradle.plugin", "5.2.0")
+	implementation("com.expediagroup.graphql", "com.expediagroup.graphql.gradle.plugin", "6.3.5")
 	implementation("com.github.johnrengelman.shadow", "com.github.johnrengelman.shadow.gradle.plugin", "7.1.2")
 }

--- a/buildSrc/src/main/kotlin/cozy-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/cozy-module.gradle.kts
@@ -67,7 +67,7 @@ tasks {
 		withType<KotlinCompile>().configureEach {
 			kotlinOptions {
 				jvmTarget = "17"
-				freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+				freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 			}
 		}
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -70,7 +70,7 @@ complexity:
     threshold: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false
-  ComplexMethod:
+  CyclomaticComplexMethod:
     active: false
     threshold: 15
     ignoreSingleWhenExpression: false
@@ -245,7 +245,7 @@ formatting:
     active: true
     autoCorrect: true
   Filename:
-    active: true
+    active: false
   FinalNewline:
     active: true
     autoCorrect: true
@@ -257,8 +257,6 @@ formatting:
   Indentation:
     active: false
     autoCorrect: false
-    indentSize: 4
-    continuationIndentSize: 4
   MaximumLineLength:
     active: true
     maxLineLength: 120
@@ -309,7 +307,6 @@ formatting:
   ParameterListWrapping:
     active: true
     autoCorrect: true
-    indentSize: 4
   SpacingAroundColon:
     active: true
     autoCorrect: true
@@ -448,8 +445,6 @@ potential-bugs:
   active: true
   Deprecation:
     active: true
-  DuplicateCaseInWhenExpression:
-    active: true
   EqualsAlwaysReturnsTrueOrFalse:
     active: true
   EqualsWithHashCodeExist:
@@ -474,15 +469,11 @@ potential-bugs:
   LateinitUsage:
     active: false
     excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
-    excludeAnnotatedProperties: [ ]
+    ignoreAnnotated: [ ]
     ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     active: true
-  MissingWhenCase:
-    active: true
   NullableToStringCall:
-    active: true
-  RedundantElseInWhen:
     active: true
   UnconditionalJumpStatementInLoop:
     active: true
@@ -509,7 +500,7 @@ style:
     active: true
   DataClassContainsFunctions:
     active: true
-    conversionFunctionPrefix: 'to'
+    conversionFunctionPrefix: ['to']
   DataClassShouldBeImmutable:
     active: true
   EqualsNullCall:
@@ -534,9 +525,6 @@ style:
   ForbiddenMethodCall:
     active: false
     methods: [ ]
-  ForbiddenPublicDataClass:
-    active: false
-    ignorePackages: [ '*.internal', '*.internal.*' ]
   ForbiddenVoid:
     active: true
     ignoreOverridden: true
@@ -544,12 +532,8 @@ style:
   FunctionOnlyReturningConstant:
     active: true
     ignoreOverridableFunction: true
-    excludedFunctions: 'describeContents'
-    excludeAnnotatedFunction: [ 'dagger.Provides' ]
-  LibraryCodeMustSpecifyReturnType:
-    active: true
-  LibraryEntitiesShouldNotBePublic:
-    active: true
+    excludedFunctions: ['describeContents']
+    ignoreAnnotated:  [ 'dagger.Provides' ]
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 3
@@ -603,7 +587,7 @@ style:
   ReturnCount:
     active: false
     max: 2
-    excludedFunctions: 'equals'
+    excludedFunctions: ['equals']
     excludeLabeled: false
     excludeReturnFromLambda: true
     excludeGuardClauses: false
@@ -620,10 +604,10 @@ style:
     active: true
   UnderscoresInNumericLiterals:
     active: true
-    acceptableDecimalLength: 5
+    acceptableLength: 5
   UnnecessaryAbstractClass:
     active: true
-    excludeAnnotatedClasses: [ 'dagger.Module' ]
+    ignoreAnnotated: [ 'dagger.Module' ]
   UnnecessaryAnnotationUseSiteTarget:
     active: true
   UnnecessaryApply:
@@ -651,7 +635,7 @@ style:
     active: true
   UseDataClass:
     active: true
-    excludeAnnotatedClasses: [ ]
+    ignoreAnnotated: [ ]
     allowVars: false
   UseEmptyCounterpart:
     active: true
@@ -671,3 +655,12 @@ style:
     active: false
     excludes: [ '**/test/**', '**/androidTest/**', '**/*.Test.kt', '**/*.Spec.kt', '**/*.Spek.kt' ]
     excludeImports: [ 'java.util.*', 'kotlinx.android.synthetic.*' ]
+
+libraries:
+  ForbiddenPublicDataClass:
+    active: false
+    ignorePackages: [ '*.internal', '*.internal.*' ]
+  LibraryEntitiesShouldNotBePublic:
+    active: false
+  LibraryCodeMustSpecifyReturnType:
+    active: true

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,26 +1,27 @@
 [versions]
-detekt = "1.21.0-RC2"
-kotlin = "1.7.10"
-graphql = "5.3.2"
+detekt = "1.22.0"
+kotlin = "1.8.0"
+graphql = "6.3.5"
 
-commons-text = "1.9"
+commons-text = "1.10.0"
 excelkt = "1.0.2"
-groovy = "3.0.9"
-homoglyph = "1.1.1"
+groovy = "3.0.14"
+homoglyph = "1.2.0"
 jansi = "2.4.0"
-jsoup = "1.15.2"
-kaml = "0.43.0"
-kmongo = "4.5.1"
+jsoup = "1.15.3"
+kaml = "0.50.0"
+kmongo = "4.8.0"
 kordex = "1.5.6-SNAPSHOT"
-kx-ser = "1.3.3"
-logback = "1.2.5"
+kx-ser = "1.4.1"
+logback = "1.2.8"
 logging = "2.1.23"
-rgxgen = "1.3"
-semver = "1.3.0"
+rgxgen = "1.4"
+semver = "1.4.2"
 
 [libraries]
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
 detekt = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-libraries = { module = "io.gitlab.arturbosch.detekt:detekt-rules-libraries", version.ref = "detekt" }
 excelkt = { module = "io.github.evanrupert:excelkt", version.ref = "excelkt" }
 graphql = { module = "com.expediagroup:graphql-kotlin-ktor-client", version.ref = "graphql" }
 groovy = { module = "org.codehaus.groovy:groovy", version.ref = "groovy" }

--- a/module-moderation/build.gradle.kts
+++ b/module-moderation/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 dependencies {
 	detektPlugins(libs.detekt)
+	detektPlugins(libs.detekt.libraries)
 
 	ksp(libs.kordex.annotationProcessor)
 

--- a/module-role-sync/build.gradle.kts
+++ b/module-role-sync/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 dependencies {
 	detektPlugins(libs.detekt)
+	detektPlugins(libs.detekt.libraries)
 
 	ksp(libs.kordex.annotationProcessor)
 

--- a/module-tags/build.gradle.kts
+++ b/module-tags/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 dependencies {
 	detektPlugins(libs.detekt)
+	detektPlugins(libs.detekt.libraries)
 
 	ksp(libs.kordex.annotationProcessor)
 

--- a/module-tags/src/main/kotlin/org/quiltmc/community/cozy/modules/tags/TagsExtension.kt
+++ b/module-tags/src/main/kotlin/org/quiltmc/community/cozy/modules/tags/TagsExtension.kt
@@ -23,6 +23,7 @@ import com.kotlindiscord.kord.extensions.types.editingPaginator
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.utils.FilterStrategy
 import com.kotlindiscord.kord.extensions.utils.suggestStringMap
+import dev.kord.common.annotation.KordUnsafe
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.behavior.interaction.modal
 import dev.kord.core.behavior.interaction.suggestString
@@ -201,6 +202,7 @@ public class TagsExtension : Extension() {
 
 			tagsConfig.getStaffCommandChecks().forEach(::check)
 
+			@OptIn(KordUnsafe::class)
 			unsafeSubCommand(::SetArgs) {
 				name = "set"
 				description = "Create or replace a tag"
@@ -249,6 +251,7 @@ public class TagsExtension : Extension() {
 				}
 			}
 
+			@OptIn(KordUnsafe::class)
 			unsafeSubCommand(::EditArgs) {
 				name = "edit"
 				description = "Edit an existing tag"

--- a/module-user-cleanup/build.gradle.kts
+++ b/module-user-cleanup/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 dependencies {
 	detektPlugins(libs.detekt)
+	detektPlugins(libs.detekt.libraries)
 
 	ksp(libs.kordex.annotationProcessor)
 

--- a/module-welcome/build.gradle.kts
+++ b/module-welcome/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 dependencies {
 	detektPlugins(libs.detekt)
+	detektPlugins(libs.detekt.libraries)
 
 	ksp(libs.kordex.annotationProcessor)
 

--- a/module-welcome/src/main/kotlin/org/quiltmc/community/cozy/modules/welcome/blocks/RolesBlock.kt
+++ b/module-welcome/src/main/kotlin/org/quiltmc/community/cozy/modules/welcome/blocks/RolesBlock.kt
@@ -22,6 +22,7 @@ import dev.kord.core.entity.Role
 import dev.kord.core.event.interaction.ButtonInteractionCreateEvent
 import dev.kord.core.event.interaction.InteractionCreateEvent
 import dev.kord.core.event.interaction.SelectMenuInteractionCreateEvent
+import dev.kord.rest.builder.component.option
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.create.MessageCreateBuilder
 import dev.kord.rest.builder.message.create.actionRow

--- a/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/github/GithubExtension.kt
+++ b/src/main/kotlin/org/quiltmc/community/modes/quilt/extensions/github/GithubExtension.kt
@@ -283,7 +283,8 @@ class GithubExtension : Extension() {
 												val loginAndId = getActorLoginAndId(issue.author!!)
 
 												name = "Issue Author"
-												value = "${loginAndId.first} (${loginAndId.second})"
+												value = "${loginAndId?.first} " +
+														"(${loginAndId?.second ?: "Unable to get actor login and id"})"
 											}
 
 											userField(user, "Moderator")
@@ -320,13 +321,14 @@ class GithubExtension : Extension() {
 	}
 
 	// Yes, this is stupid.
-	private fun getActorLoginAndId(actor: Actor): Pair<String, String> {
+	private fun getActorLoginAndId(actor: Actor): Pair<String, String>? {
 		return when (actor) {
 			is EnterpriseUserAccount -> Pair(actor.login, actor.id)
 			is Organization -> Pair(actor.login, actor.id)
 			is Bot -> Pair(actor.login, actor.id)
 			is Mannequin -> Pair(actor.login, actor.id)
 			is User -> Pair(actor.login, actor.id)
+			else -> null
 		}
 	}
 


### PR DESCRIPTION
Detekt changes were made to keep parity with how it was prior to the update. The same reasons as in the KordEx update