### PR TITLE
Add a check to FabricApisProcessor.kt for the FLK replacement warn

### DIFF
--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/processors/quilt/FabricApisProcessor.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/processors/quilt/FabricApisProcessor.kt
@@ -22,6 +22,7 @@ public class FabricApisProcessor : LogProcessor() {
 	override suspend fun process(log: Log) {
 		val fabricApi = log.getMod("fabric")
 		val fabricLanguageKotlin = log.getMod("fabric-language-kotlin")
+		val quiltStandardLibraries = log.getMod("qsl")
 
 		if (fabricApi != null) {
 			log.hasProblems = true
@@ -31,7 +32,7 @@ public class FabricApisProcessor : LogProcessor() {
 			)
 		}
 
-		if (fabricLanguageKotlin != null) {
+		if (fabricLanguageKotlin != null && quiltStandardLibraries != null) {
 			log.hasProblems = true
 
 			log.addMessage(


### PR DESCRIPTION
Fixes #82 (I think?), checking if Quilt Standard Libraries are present before asking the user to replace Fabric Language Kotlin by Quilt Kotlin Libraries because it makes no sense to replace it if the user only has Fabric API.