### PR TITLE
Add fabric mod used when quilt version exists log processor

### DIFF
--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/config/SimpleLogParserConfig.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/config/SimpleLogParserConfig.kt
@@ -51,6 +51,7 @@ public class SimpleLogParserConfig(private val builder: Builder) : LogParserConf
 			FabricApisProcessor(),
 			FabricImplProcessor(),
 			IncompatibleModProcessor(),
+			FabricModUsedWhenQuiltVersionExistsProcessor(),
 			CrashReportProcessor(),
 			JavaClassFileVersionProcessor(),
 			MixinErrorProcessor(),

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/data/Mod.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/data/Mod.kt
@@ -14,5 +14,6 @@ public data class Mod(
 
 	// Only present on Quilt Loader
 	val path: String?,
-	val hash: String?
+	val hash: String?,
+	val type: String?
 )

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/data/Mod.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/data/Mod.kt
@@ -11,6 +11,8 @@ import org.quiltmc.community.cozy.modules.logs.Version
 public data class Mod(
 	val id: String,
 	val version: Version,
+
 	// Only present on Quilt Loader
-	val path: String?
+	val path: String?,
+	val hash: String?
 )

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/fabric/FabricModsParser.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/fabric/FabricModsParser.kt
@@ -38,6 +38,7 @@ public class FabricModsParser : LogParser() {
 						split.first(),
 						Version(split.last()),
 						null,
+						null,
 						null
 					)
 				)

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/fabric/FabricModsParser.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/fabric/FabricModsParser.kt
@@ -37,6 +37,7 @@ public class FabricModsParser : LogParser() {
 					Mod(
 						split.first(),
 						Version(split.last()),
+						null,
 						null
 					)
 				)

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/quilt/QuiltModsParser.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/quilt/QuiltModsParser.kt
@@ -73,7 +73,8 @@ public class QuiltModsParser : LogParser() {
 				Mod(
 					mod["id"]!!,
 					Version(mod["version"]!!),
-					mod["file(s)"]
+					mod["file(s)"],
+					mod["File Hash (SHA-1)"]
 				)
 			)
 		}

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/quilt/QuiltModsParser.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/quilt/QuiltModsParser.kt
@@ -74,7 +74,8 @@ public class QuiltModsParser : LogParser() {
 					mod["id"]!!,
 					Version(mod["version"]!!),
 					mod["file(s)"],
-					mod["File Hash (SHA-1)"]
+					mod["File Hash (SHA-1)"],
+					mod["Type"]
 				)
 			)
 		}

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/quilt/QuiltModsParser.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/parsers/quilt/QuiltModsParser.kt
@@ -38,7 +38,7 @@ public class QuiltModsParser : LogParser() {
 
 		val lines = table
 			.split("\n")
-			.map { it.trim('|') }  // Don't strip spaces here, but do remove border pipes
+			.map { it.trim().trim('|') }  // Don't strip spaces here, but do remove border pipes
 			.toMutableList()
 
 		// The first line is the headers
@@ -74,8 +74,8 @@ public class QuiltModsParser : LogParser() {
 					mod["id"]!!,
 					Version(mod["version"]!!),
 					mod["file(s)"],
-					mod["File Hash (SHA-1)"],
-					mod["Type"]
+					mod["file hash (sha-1)"],
+					mod["type"]
 				)
 			)
 		}

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/processors/quilt/FabricModUsedWhenQuiltVersionExistsProcessor.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/processors/quilt/FabricModUsedWhenQuiltVersionExistsProcessor.kt
@@ -38,13 +38,12 @@ public class FabricModUsedWhenQuiltVersionExistsProcessor : LogProcessor() {
 	override suspend fun process(log: Log) {
 		val mcVersion = log.minecraftVersion?.string ?: log.getMod("minecraft")?.version?.string ?: return
 
-		val hashToMod = log.getMods().filter {
-			it.value.type?.lowercase(Locale.getDefault()).equals("fabric") && it.value.hash != null
-		}.map { (_, mod) -> mod.hash!! to mod }.toMap()
+		val hashToMod = log.getMods().values.filter {
+			it.type?.lowercase(Locale.getDefault()) == "fabric" && it.hash != null
+		}.associateBy { it.hash!! }
 		if (hashToMod.isEmpty()) return
 
-		val hashesRequest = client.post {
-			url("$MODRINTH_API_BASE/version_files")
+		val hashesRequest = client.post("$MODRINTH_API_BASE/version_files") {
 			setBody(json.encodeToString(HashLookupParam(hashToMod.keys.toList(), "sha1")))
 			contentType(ContentType.Application.Json)
 		}

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/processors/quilt/FabricModUsedWhenQuiltVersionExistsProcessor.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/processors/quilt/FabricModUsedWhenQuiltVersionExistsProcessor.kt
@@ -1,0 +1,149 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.quiltmc.community.cozy.modules.logs.processors.quilt
+
+import dev.kord.core.event.Event
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.decodeFromJsonElement
+import org.quiltmc.community.cozy.modules.logs.Version
+import org.quiltmc.community.cozy.modules.logs.data.LoaderType
+import org.quiltmc.community.cozy.modules.logs.data.Log
+import org.quiltmc.community.cozy.modules.logs.data.Order
+import org.quiltmc.community.cozy.modules.logs.types.LogProcessor
+import java.util.*
+
+private const val MODRINTH_API_BASE = "https://api.modrinth.com/v2"
+
+public class FabricModUsedWhenQuiltVersionExistsProcessor : LogProcessor() {
+
+	override val identifier: String = "fabric-mod-used-when-quilt-version-exists"
+	override val order: Order = Order.Default
+	private val json = Json {
+		ignoreUnknownKeys = true
+	}
+
+	override suspend fun predicate(log: Log, event: Event): Boolean = log.getLoaderVersion(LoaderType.Quilt) != null
+
+	override suspend fun process(log: Log) {
+		val mcVersion = log.minecraftVersion?.string ?: log.getMod("minecraft")?.version?.string ?: return
+
+		val hashToMod = log.getMods().filter {
+			it.value.type?.lowercase(Locale.getDefault()).equals("fabric") && it.value.hash != null
+		}.map { (_, mod) -> mod.hash!! to mod }.toMap()
+		if (hashToMod.isEmpty()) return
+
+		val hashesRequest = client.post {
+			url("$MODRINTH_API_BASE/version_files")
+			setBody(json.encodeToString(HashLookupParam(hashToMod.keys.toList(), "sha1")))
+			contentType(ContentType.Application.Json)
+		}
+		if (hashesRequest.status != HttpStatusCode.OK) return
+
+		val projectIdToNoneQuiltVersions = json.decodeFromJsonElement<Map<String, Version>>(hashesRequest.body())
+			.filter { !it.value.loaders.contains("quilt") }
+			.map { (hash, version) -> version.projectId to hashToMod[hash] }
+			.toMap()
+		if (projectIdToNoneQuiltVersions.isEmpty()) return
+
+		val projectsRequest = client.get("$MODRINTH_API_BASE/projects") {
+			url {
+				parameters.append("ids", json.encodeToString(projectIdToNoneQuiltVersions.keys.toList()))
+			}
+		}
+		if (projectsRequest.status != HttpStatusCode.OK) return
+
+		val body = projectsRequest.body<JsonArray>()
+		val potentialBetterVersionCandidates = json.decodeFromJsonElement<List<Project>>(body)
+			.filter { it.gameVersions.contains(mcVersion) && it.loaders.contains("quilt") }
+			.flatMap { it.versions }
+		if (potentialBetterVersionCandidates.isEmpty()) return
+
+		val versionsRequest = client.get("$MODRINTH_API_BASE/versions") {
+			url {
+				parameters.append("ids", json.encodeToString(potentialBetterVersionCandidates))
+			}
+		}
+		if (versionsRequest.status != HttpStatusCode.OK) return
+
+		val modIdToProjectVersion = mutableMapOf<String, MutableList<Version>>()
+		json.decodeFromJsonElement<List<Version>>(versionsRequest.body())
+			.filter { it.loaders.contains("quilt") && it.gameVersions.contains(mcVersion) }
+			.forEach {
+				val mod = projectIdToNoneQuiltVersions[it.projectId]!!
+				val version = Version(removeLoaderIdentifier(it.versionNumber))
+				val oldVersion = Version(removeLoaderIdentifier(mod.version.string))
+				if (version >= oldVersion) {
+					modIdToProjectVersion.getOrPut(mod.id) { mutableListOf<Version>() }.add(it)
+				}
+			}
+		if (modIdToProjectVersion.isEmpty()) return
+
+		val modsWithNewerVersions = mutableListOf<String>()
+		for ((modid, versions) in modIdToProjectVersion) {
+			val mod = log.getMod(modid)!!
+			if (versions.size == 1) {
+				val version = versions[0]
+				val oldMod = projectIdToNoneQuiltVersions[version.projectId]!!
+				modsWithNewerVersions.add(
+					"`${mod.id}`: Switch from ${oldMod.version.string} to " +
+					"[${version.versionNumber} (Modrinth)]" +
+					"(https://modrinth.com/mod/${version.projectId}/version/${versions[0].id})"
+				)
+			} else {
+				modsWithNewerVersions.add(
+					"`${mod.id}`: See [Modrinth](https://modrinth.com/mod/" +
+					"${versions[0].projectId}/versions?l=quilt&v=$mcVersion)"
+				)
+			}
+		}
+		log.addMessage(
+			buildString {
+				appendLine(
+					"The following fabric mods are marked as fabric only on Modrinth, " +
+					"but newer or alternative versions with explicit quilt support exist:"
+				)
+				for (mod in modsWithNewerVersions) {
+					appendLine(" - $mod")
+				}
+			}
+		)
+	}
+
+	private fun removeLoaderIdentifier(versionNumber: String): String = versionNumber.lowercase()
+		.replace(Regex("quilt[-+ ]"), "")
+		.replace(Regex("fabric[-+ ]"), "")
+		.replace(Regex("[-+ ]quilt"), "")
+		.replace(Regex("[-+ ]fabric"), "")
+		.replace("quilt", "")
+		.replace("fabric", "")
+
+	@Serializable
+	public data class Project(
+		public val versions: List<String>,
+		@SerialName("game_versions") public val gameVersions: List<String>,
+		public val loaders: List<String>
+	)
+
+	@Serializable
+	public data class HashLookupParam(public val hashes: List<String>, public val algorithm: String)
+
+	@Serializable
+	public data class Version(
+		public val loaders: List<String>,
+		@SerialName("project_id") public val projectId: String,
+		@SerialName("version_number") public val versionNumber: String,
+		@SerialName("game_versions") public val gameVersions: List<String>,
+		public val id: String
+	)
+}

--- a/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/types/LogProcessor.kt
+++ b/module-log-parser/src/main/kotlin/org/quiltmc/community/cozy/modules/logs/types/LogProcessor.kt
@@ -11,6 +11,7 @@ import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
 import dev.kord.core.event.Event
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
@@ -29,6 +30,9 @@ public abstract class LogProcessor : BaseLogHandler, KordExKoinComponent {
 				kotlinx.serialization.json.Json { ignoreUnknownKeys = true },
 				ContentType.Any
 			)
+		}
+		install(UserAgent) {
+			agent = "QuiltMC/cozy-discord (quiltmc.org)"
 		}
 	}
 


### PR DESCRIPTION
- Additionally extract the mod type and hash from the mod table
- When for all fabric mods, do a hash lookup via the [Modrinth's version_files API](https://docs.modrinth.com/#tag/version-files/operation/versionsFromHashes).
- Get the project of all of the versions not marked as compatible to quilt using [Modrinth's projects API](https://docs.modrinth.com/#tag/projects/operation/getProjects) 
- Get the versions of all of the projects where a version with the right mc version and a version with quilt support exists using [Modrinth's versions API](https://docs.modrinth.com/#tag/versions/operation/scheduleVersion)
- For all versions supporting the mc version and explicitly supporting Quilt:
  - Compare the versions (with mod markers removed) using FlexVer, if the version on modrinth is larger or equal to the installed mod's version, add it to the upgrade options for that mod.
- For all mods with such an upgrade option:
  - If only a single option exists, link to that directly
  - else link to all versions for the mc version supporting quilt

As all the API requests are batch requests, a maximum of three (sequential) API requests are required.

![image](https://github.com/QuiltMC/cozy-discord/assets/61744596/c905b2a5-4741-4861-a5cc-a5e0dbf52a92)
