### PR TITLE
Add dispatch job to auto-update Helm chart

### DIFF
--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -73,3 +73,11 @@ jobs:
       - run: docker build -t ghcr.io/quiltmc/cozy-discord:latest -t ghcr.io/quiltmc/cozy-discord:${GITHUB_SHA} .
       - run: docker push ghcr.io/quiltmc/cozy-discord:latest
       - run: docker push ghcr.io/quiltmc/cozy-discord:${GITHUB_SHA}
+
+      - name: Dispatch quilt-helm-charts update event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+            token: ${{ secrets.QHC_TOKEN }}
+            repository: QuiltMC/quilt-helm-charts
+            event-type: cozy_update
+            client-payload: '{"tag": "${{ github.sha }}"}'


### PR DESCRIPTION
Follow-up to https://github.com/QuiltMC/quilt-helm-charts/pull/5

This PR adds a step to the main branch's workflow, which triggers another workflow in the quilt-helm-charts repository, which will in turn update the chart with the latest cozy version, which will be picked up by our infrastructure and trigger an automated update. This requires an access token in a secret named `QHC_TOKEN`, with the read&write permission for the quilt-helm-charts repository.